### PR TITLE
Fix undefined error variable in raffle loader

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -3639,6 +3639,7 @@ async function cargarSorteos(){
     // 1) Tickets activos (sumatoria en tickets_ledger)
     let totalTickets = 0;
     let tksRows = [];
+    let tErr = null;
     try{
       ({ data: tksRows, error: tErr } = await supabase
         .from('tickets_ledger')

--- a/index.html
+++ b/index.html
@@ -3570,6 +3570,7 @@ async function cargarSorteos(){
     // 1) Tickets activos (sumatoria en tickets_ledger)
     let totalTickets = 0;
     let tksRows = [];
+    let tErr = null;
     try{
       ({ data: tksRows, error: tErr } = await supabase
         .from('tickets_ledger')


### PR DESCRIPTION
## Summary
- declare `tErr` before using in `cargarSorteos` to avoid leaking a global variable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cff981fc8330b2d4f48cb42e5b0f