### PR TITLE
feat: add button transitions and entry animations

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -98,6 +98,18 @@
     .form-actions{ display:flex; gap:.6rem; justify-content:flex-end; margin-top:1rem; }
     .btn{ background:var(--primary); color:var(--dark); border:0; padding:.6rem 1rem; border-radius:8px; font-weight:600; cursor:pointer; }
     .btn:hover{ background: var(--primary-dark); }
+    /* Smooth hover transitions for buttons and cards */
+    button, .stat-card, .settings-card, .srt-card, .pd-card, .sc-card, .card, .product-card{
+      transition: transform .2s ease, box-shadow .2s ease;
+    }
+    button:hover, .stat-card:hover, .settings-card:hover, .srt-card:hover, .pd-card:hover, .sc-card:hover, .card:hover{
+      transform: translateY(-2px);
+      box-shadow: 0 8px 24px rgba(0,0,0,.35);
+    }
+    /* Entry animations */
+    .section-title, .product-card{ opacity:0; transform:translateY(20px); }
+    .section-title.animate-in, .product-card.animate-in{ animation:fadeInUp .6s ease forwards; }
+    @keyframes fadeInUp{ to{ opacity:1; transform:translateY(0); } }
     #section-productos .products-wrap{ max-width:1100px; margin:0 auto; padding: .5rem 1rem 0; }
     #section-productos .products-grid{ display:grid; grid-template-columns: repeat(2, 1fr); gap:1.5rem; justify-items:center; }
     #section-productos .product-card{ width:100%; max-width:500px; border-radius:16px; background: var(--dark-light); border:1px solid rgba(255,255,255,.05); overflow:hidden; display:flex; flex-direction:column; transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease; }
@@ -796,6 +808,20 @@
       obs.observe(root, {childList: true, subtree: true});
     }catch(_){}
   })();
+</script>
+
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  var observer = new IntersectionObserver(function(entries){
+    entries.forEach(function(entry){
+      if(entry.isIntersecting){
+        entry.target.classList.add('animate-in');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+  document.querySelectorAll('.section-title, .product-card').forEach(function(el){ observer.observe(el); });
+});
 </script>
 
 <style id="theme-futurista-sidebar">

--- a/index.html
+++ b/index.html
@@ -98,6 +98,18 @@
     .form-actions{ display:flex; gap:.6rem; justify-content:flex-end; margin-top:1rem; }
     .btn{ background:var(--primary); color:var(--dark); border:0; padding:.6rem 1rem; border-radius:8px; font-weight:600; cursor:pointer; }
     .btn:hover{ background: var(--primary-dark); }
+    /* Smooth hover transitions for buttons and cards */
+    button, .stat-card, .settings-card, .srt-card, .pd-card, .sc-card, .card, .product-card{
+      transition: transform .2s ease, box-shadow .2s ease;
+    }
+    button:hover, .stat-card:hover, .settings-card:hover, .srt-card:hover, .pd-card:hover, .sc-card:hover, .card:hover{
+      transform: translateY(-2px);
+      box-shadow: 0 8px 24px rgba(0,0,0,.35);
+    }
+    /* Entry animations */
+    .section-title, .product-card{ opacity:0; transform:translateY(20px); }
+    .section-title.animate-in, .product-card.animate-in{ animation:fadeInUp .6s ease forwards; }
+    @keyframes fadeInUp{ to{ opacity:1; transform:translateY(0); } }
     #section-productos .products-wrap{ max-width:1100px; margin:0 auto; padding: .5rem 1rem 0; }
     #section-productos .products-grid{ display:grid; grid-template-columns: repeat(2, 1fr); gap:1.5rem; justify-items:center; }
     #section-productos .product-card{ width:100%; max-width:500px; border-radius:16px; background: var(--dark-light); border:1px solid rgba(255,255,255,.05); overflow:hidden; display:flex; flex-direction:column; transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease; }
@@ -799,6 +811,20 @@
       obs.observe(root, {childList: true, subtree: true});
     }catch(_){}
   })();
+</script>
+
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  var observer = new IntersectionObserver(function(entries){
+    entries.forEach(function(entry){
+      if(entry.isIntersecting){
+        entry.target.classList.add('animate-in');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+  document.querySelectorAll('.section-title, .product-card').forEach(function(el){ observer.observe(el); });
+});
 </script>
 </head>
 <body>

--- a/login.html
+++ b/login.html
@@ -80,9 +80,14 @@
     input:focus{ border-color:#2e3746; box-shadow:0 0 0 3px rgba(255,215,0,.15); }
     .login-button{
       width:100%; background:var(--brand); color:#111; border:0; border-radius:999px;
-      padding:12px 14px; font-weight:900; cursor:pointer; transition:.18s transform;
+      padding:12px 14px; font-weight:900; cursor:pointer; transition:.18s transform, .18s box-shadow;
     }
-    .login-button:hover{ transform:translateY(-1px); }
+    .login-button:hover{ transform:translateY(-1px); box-shadow:0 6px 18px rgba(0,0,0,.3); }
+    /* Generic button transitions */
+    button{ transition:transform .2s ease, box-shadow .2s ease; }
+    button:hover{ transform:translateY(-2px); box-shadow:0 8px 24px rgba(0,0,0,.35); }
+    .login-container{ transition:transform .2s ease, box-shadow .2s ease; }
+    .login-container:hover{ transform:translateY(-2px); box-shadow:0 24px 48px rgba(0,0,0,.5); }
     .toggle-form{ display:block; margin-top:10px; color:var(--brand); cursor:pointer; text-align:center; }
     .toggle-form:hover{ text-decoration:underline; }
     #error-message, #register-error-message, #reset-error, #reset-success, #newpass-error, #newpass-success{

--- a/reset-password.html
+++ b/reset-password.html
@@ -89,10 +89,13 @@
     .btn{
       display:block; margin:16px auto 0;
       width:min(360px,100%); background:var(--brand); color:#111; border:0; border-radius:999px;
-      padding:12px 14px; font-weight:900; cursor:pointer; transition:.18s transform;
+      padding:12px 14px; font-weight:900; cursor:pointer; transition:.18s transform, .18s box-shadow;
       text-align:center;
     }
-    .btn:hover{ transform:translateY(-1px); }
+    .btn:hover{ transform:translateY(-1px); box-shadow:0 6px 18px rgba(0,0,0,.3); }
+    /* Generic button & card transitions */
+    button, .card{ transition:transform .2s ease, box-shadow .2s ease; }
+    button:hover, .card:hover{ transform:translateY(-2px); box-shadow:0 8px 24px rgba(0,0,0,.35); }
 
     .muted{ color:var(--muted); font-size:.9rem; text-align:center; margin-top:12px; }
     a.link{ color:var(--brand); text-decoration:none; }


### PR DESCRIPTION
## Summary
- smooth transform and box-shadow transitions for buttons and cards
- fade-in entry animations for section titles and product cards using IntersectionObserver
- update auth pages with consistent hover effects

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d44bb43c83309c54af2cdc116308