### PR TITLE
Fix login redirect in reset password page

### DIFF
--- a/reset-password.html
+++ b/reset-password.html
@@ -243,7 +243,7 @@
         const { error } = await supabaseClient.auth.updateUser({ password: p1 });
         if (error){ err.textContent = error.message || t.err; return; }
         ok.textContent = t.ok;
-        setTimeout(()=> { window.location.href = "/login.html"; }, 1200);
+        setTimeout(()=> { window.location.href = "login.html"; }, 1200);
       }catch(e){ err.textContent = e?.message || t.err; }
     });
   </script>


### PR DESCRIPTION
## Summary
- use a relative path for login redirect in reset-password.html

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d3e95b148330bf6a897603d35c62