### PR TITLE
Add Playwright tests for login page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+playwright-report/
+
+test-results/

--- a/login.html
+++ b/login.html
@@ -620,12 +620,6 @@ const redirectTo = RESET_REDIRECT_URL; // -> en producción envía al formulario
         }
       });
 
-      // Autotests en consola
-      console.groupCollapsed('NUMINA login+reset self-tests');
-      console.assert(document.getElementById('forgot-link'), 'Existe link "olvidaste tu contraseña"');
-      console.assert(document.getElementById('reset-form'), 'Existe formulario de reset');
-      console.assert(document.getElementById('newpass-form'), 'Existe formulario de nueva contraseña');
-      console.groupEnd();
     });
   </script>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "numina5555.github.io",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "numina5555.github.io",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.55.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "numina5555.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.55.0"
+  }
+}

--- a/tests/login.spec.js
+++ b/tests/login.spec.js
@@ -1,0 +1,20 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test.describe('login page', () => {
+  test('contains forms and shows reset form when link clicked', async ({ page }) => {
+    const filePath = 'file://' + path.resolve(__dirname, '../login.html');
+    await page.goto(filePath);
+
+    await expect(page.locator('#login-form')).toHaveCount(1);
+    await expect(page.locator('#register-form')).toHaveCount(1);
+    await expect(page.locator('#reset-form')).toHaveCount(1);
+    await expect(page.locator('#newpass-form')).toHaveCount(1);
+
+    // reset form should be hidden initially
+    await expect(page.locator('#reset-form')).toBeHidden();
+
+    await page.locator('#forgot-link').click();
+    await expect(page.locator('#reset-form')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- remove in-page console assertions and rely on external tests
- add Playwright test verifying login page forms and reset link behavior
- run Playwright tests in CI via GitHub Actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7d3f982188330bc2a8e22fd5fb4b1