### PR TITLE
feat: refresh theme colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,13 +10,14 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
   <style>
     :root {
-      --primary: #ffd700;
-      --primary-dark: #e6c200;
-      --dark: #111;
-      --dark-light: #1a1a1a;
-      --dark-lighter: #222;
-      --text: #fff;
-      --text-light: #ccc;
+      --primary: #4a90e2;
+      --primary-dark: #357abd;
+      --secondary: #50e3c2;
+      --dark: #f4f6f8;
+      --dark-light: #ffffff;
+      --dark-lighter: #eef1f5;
+      --text: #333;
+      --text-light: #555;
       --success: #28a745;
       --warning: #ffc107;
       --danger: #dc3545;
@@ -24,36 +25,36 @@
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { overflow-y: scroll; }
     body { font-family: 'Montserrat', sans-serif; background: var(--dark); color: var(--text); min-height: 100vh; display:flex; flex-direction:column; }
-    .dashboard-header { background: linear-gradient(to right, var(--dark), var(--dark-lighter)); padding: 1rem 2rem; display:flex; justify-content:space-between; align-items:center; border-bottom: 1px solid rgba(255,215,0,.1); }
-    .logo { color: var(--primary); font-size: 1.8rem; font-weight: 700; letter-spacing: 1px; }
+    .dashboard-header { background: linear-gradient(135deg, var(--primary), var(--secondary)); padding: 1rem 2rem; display:flex; justify-content:space-between; align-items:center; border-bottom: 1px solid rgba(0,0,0,.1); color:#fff; }
+    .logo { color: #fff; font-size: 1.8rem; font-weight: 700; letter-spacing: 1px; }
     .user-menu { display:flex; align-items:center; gap:1rem; }
-    .user-avatar { width: 40px; height: 40px; border-radius: 50%; background: var(--primary); color: var(--dark); display:flex; align-items:center; justify-content:center; font-weight:700; cursor: default; }
+    .user-avatar { width: 40px; height: 40px; border-radius: 50%; background: var(--secondary); color:#fff; display:flex; align-items:center; justify-content:center; font-weight:700; cursor: default; }
     .dashboard-container { display:flex; flex:1; }
-    .sidebar { width: 250px; background: var(--dark-light); padding: 1.5rem 0; border-right: 1px solid rgba(255,255,255,.05); }
+    .sidebar { width: 250px; background: var(--dark-light); padding: 1.5rem 0; border-right: 1px solid rgba(0,0,0,.1); }
     .sidebar-menu { list-style: none; }
     .menu-item { padding: .8rem 1.5rem; display:flex; align-items:center; gap:.8rem; cursor:pointer; transition: .2s ease; border-left: 3px solid transparent; }
-    .menu-item:hover, .menu-item.active { background-color: rgba(255,215,0,.1); border-left-color: var(--primary); color: var(--primary); }
+    .menu-item:hover, .menu-item.active { background-color: var(--secondary); border-left-color: var(--primary); color:#fff; }
     .menu-item i { width: 20px; text-align:center; }
     .main-content { flex:1; padding: 2rem; background: var(--dark); }
-    .welcome-banner { background: linear-gradient(135deg, rgba(255,215,0,.1), rgba(255,215,0,.05)); border: 1px solid rgba(255,215,0,.1); border-radius:10px; padding:1.5rem; margin-bottom:2rem; display:flex; justify-content:space-between; align-items:center; gap:1rem; }
+    .welcome-banner { background: linear-gradient(135deg, rgba(74,144,226,.1), rgba(80,227,194,.05)); border: 1px solid rgba(74,144,226,.1); border-radius:10px; padding:1.5rem; margin-bottom:2rem; display:flex; justify-content:space-between; align-items:center; gap:1rem; }
     .welcome-text h2 { color: var(--primary); margin-bottom:.5rem; white-space:nowrap; min-height:1.6em; display:flex; align-items:center; }
     .welcome-text p { color: var(--text-light); }
     .welcome-right { display:flex; flex-direction:column; align-items:flex-end; gap:.6rem; }
     .lang-dropdown{ position:relative; display:inline-block; }
-    .lang-btn{ background:#ffd700; border:0; border-radius:999px; padding:6px 12px; cursor:pointer; color:#111; font-weight:800; display:inline-flex; align-items:center; gap:8px; box-shadow:inset 0 -2px 0 rgba(0,0,0,.15), 0 2px 8px rgba(0,0,0,.25); }
-    .lang-btn:focus{ outline:none; box-shadow:0 0 0 3px rgba(255,215,0,.3); }
-    .lang-btn .chevron{ width:12px; height:12px; fill:none; stroke:#111; stroke-width:2px; transition:transform .18s ease; }
+    .lang-btn{ background:var(--secondary); border:0; border-radius:999px; padding:6px 12px; cursor:pointer; color:#fff; font-weight:800; display:inline-flex; align-items:center; gap:8px; box-shadow:inset 0 -2px 0 rgba(0,0,0,.15), 0 2px 8px rgba(0,0,0,.25); }
+    .lang-btn:focus{ outline:none; box-shadow:0 0 0 3px rgba(80,227,194,.3); }
+    .lang-btn .chevron{ width:12px; height:12px; fill:none; stroke:#fff; stroke-width:2px; transition:transform .18s ease; }
     .lang-dropdown.open .chevron{ transform: rotate(180deg); }
     .lang-menu{ position:absolute; top:110%; right:0; z-index:100; background:#fff; color:#111; border-radius:12px; padding:6px 0; margin:8px 0 0; box-shadow:0 12px 28px rgba(0,0,0,.25), 0 2px 8px rgba(0,0,0,.2); min-width:170px; list-style:none; display:none; max-height:260px; overflow:auto; }
     .lang-dropdown.open .lang-menu{ display:block; }
     .lang-item{ display:flex; align-items:center; gap:10px; padding:10px 14px; cursor:pointer; font-weight:700; user-select:none; white-space:nowrap; }
-    .lang-item:hover, .lang-item[aria-selected="true"]{ background:#ffd700; color:#111; }
+    .lang-item:hover, .lang-item[aria-selected="true"]{ background:var(--secondary); color:#fff; }
     .lang-flag{ width:18px; height:18px; display:inline-flex; align-items:center; justify-content:center; }
     .referral-code{ background: var(--dark-light); padding:.8rem 1.2rem; border-radius:8px; display:flex; align-items:center; gap:.8rem; }
-    .copy-btn{ background: var(--primary); color: var(--dark); border:0; padding:.3rem .6rem; border-radius:5px; cursor:pointer; transition:.2s ease; }
+    .copy-btn{ background: var(--primary); color:#fff; border:0; padding:.3rem .6rem; border-radius:5px; cursor:pointer; transition:.2s ease; }
     .copy-btn:hover{ background: var(--primary-dark); }
     .stats-grid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(250px,1fr)); gap:1.5rem; margin-bottom:2rem; }
-    .stat-card{ background: var(--dark-light); border-radius:10px; padding:1.5rem; border-left: 4px solid var(--primary); }
+    .stat-card{ background: var(--dark-light); border-radius:10px; padding:1.5rem; border-left: 4px solid var(--secondary); }
     .stat-card h3{ color: var(--text-light); font-size:.9rem; font-weight:500; margin-bottom:.5rem; text-transform:uppercase; letter-spacing:1px; }
     .stat-card .value{ font-size:1.8rem; font-weight:700; color: var(--primary); margin-bottom:.5rem; }
     .change{ font-size:.8rem; display:flex; align-items:center; gap:.3rem; }
@@ -65,7 +66,7 @@
     table { width:100%; border-collapse: collapse; table-layout: fixed; }
     th, td { padding:1rem; text-align:left; }
     th { background: var(--dark-lighter); color: var(--primary); font-weight:600; text-transform:uppercase; font-size:.8rem; letter-spacing:1px; }
-    td { border-bottom: 1px solid rgba(255,255,255,.05); color: var(--text-light); overflow:hidden; text-overflow:ellipsis; }
+    td { border-bottom: 1px solid rgba(0,0,0,.05); color: var(--text-light); overflow:hidden; text-overflow:ellipsis; }
     tr:last-child td{ border-bottom: none; }
     .account-info-table td:first-child{ width:30%; font-weight:700; color:#f1f1f1; }
     :root { --tbl-col-product: 42%; --tbl-col-date: 16%; --tbl-col-value: 14%; --tbl-col-status: 14%; --tbl-col-actions: 14%; }
@@ -87,16 +88,16 @@
     .status.inactive{ background: rgba(255,255,255,.12); color: #aaa; }
     .status.paid{ background: rgba(0,255,127,.18); color:#58d68d; }
     .status.disputed{ background: rgba(255,99,132,.18); color:#ff718f; }
-    .action-btn{ background:transparent; border:1px solid var(--primary); color: var(--primary); padding:.3rem .8rem; border-radius:5px; cursor:pointer; transition:.2s ease; min-width:9ch; text-align:center; }
-    .action-btn:hover{ background: var(--primary); color: var(--dark); }
-    .settings-card{ background: var(--dark-light); border: 1px solid rgba(255,255,255,.05); border-radius:10px; padding:1.5rem; margin-bottom:1.5rem; }
+    .action-btn{ background:transparent; border:1px solid var(--secondary); color: var(--secondary); padding:.3rem .8rem; border-radius:5px; cursor:pointer; transition:.2s ease; min-width:9ch; text-align:center; }
+    .action-btn:hover{ background: var(--secondary); color:#fff; }
+    .settings-card{ background: var(--dark-light); border: 1px solid rgba(0,0,0,.05); border-radius:10px; padding:1.5rem; margin-bottom:1.5rem; }
     .settings-card h3{ color: var(--primary); margin-bottom:.8rem; font-size:1.05rem; }
     .form-grid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap:1rem; }
     .form-row{ display:flex; flex-direction:column; gap:.4rem; }
     .form-row label{ color: var(--text-light); font-size:.9rem; }
     .form-row input, .form-row select{ background: var(--dark); border:1px solid var(--dark-lighter); border-radius:8px; padding:.7rem .8rem; color: var(--text); outline:none; }
     .form-actions{ display:flex; gap:.6rem; justify-content:flex-end; margin-top:1rem; }
-    .btn{ background:var(--primary); color:var(--dark); border:0; padding:.6rem 1rem; border-radius:8px; font-weight:600; cursor:pointer; }
+    .btn{ background:var(--primary); color:#fff; border:0; padding:.6rem 1rem; border-radius:8px; font-weight:600; cursor:pointer; }
     .btn:hover{ background: var(--primary-dark); }
     /* Smooth hover transitions for buttons and cards */
     button, .stat-card, .settings-card, .srt-card, .pd-card, .sc-card, .card, .product-card{
@@ -112,8 +113,8 @@
     @keyframes fadeInUp{ to{ opacity:1; transform:translateY(0); } }
     #section-productos .products-wrap{ max-width:1100px; margin:0 auto; padding: .5rem 1rem 0; }
     #section-productos .products-grid{ display:grid; grid-template-columns: repeat(2, 1fr); gap:1.5rem; justify-items:center; }
-    #section-productos .product-card{ width:100%; max-width:500px; border-radius:16px; background: var(--dark-light); border:1px solid rgba(255,255,255,.05); overflow:hidden; display:flex; flex-direction:column; transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease; }
-    #section-productos .product-card:hover{ transform: translateY(-2px); border-color: rgba(255,215,0,.25); box-shadow: 0 8px 24px rgba(0,0,0,.35); }
+    #section-productos .product-card{ width:100%; max-width:500px; border-radius:16px; background: var(--dark-light); border:1px solid rgba(0,0,0,.05); overflow:hidden; display:flex; flex-direction:column; transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease; }
+    #section-productos .product-card:hover{ transform: translateY(-2px); border-color: rgba(74,144,226,.25); box-shadow: 0 8px 24px rgba(0,0,0,.35); }
     #section-productos .product-media{ background: var(--dark-lighter); aspect-ratio:16/9; display:block; }
     #section-productos .product-body{ padding:1rem; display:flex; flex-direction:column; gap:.6rem; }
     #section-productos .product-title{ font-size:1rem; font-weight:700; color: var(--text); }
@@ -137,14 +138,14 @@
                display:flex; flex-direction:column; min-height:150px; }
     .srt-card h3{ color:var(--text-light); font-size:.9rem; text-transform:uppercase; letter-spacing:.6px; margin-bottom:.5rem; }
     .srt-card .val{ font-size:1.5rem; font-weight:800; color:var(--text-light); }
-    .srt-card.gold{ background:linear-gradient(135deg, rgba(255,215,0,.12), rgba(255,215,0,.04)); }
+    .srt-card.gold{ background:linear-gradient(135deg, rgba(74,144,226,.12), rgba(74,144,226,.04)); }
 
     /* Progreso Upgrade Numina */
     .srt-progress{ margin-top:.8rem; }
     .srt-track{ position:relative; height:14px; background:linear-gradient(180deg,#1a1a1a,#151515);
                 border:1px solid rgba(255,255,255,.08); border-radius:999px; overflow: visible; }
-    .srt-fill{ height:100%; width:0%; background:linear-gradient(90deg, rgba(255,215,0,.85), rgba(255,215,0,1));
-               box-shadow:0 0 12px rgba(255,215,0,.35) inset; transition:width .35s ease; }
+    .srt-fill{ height:100%; width:0%; background:linear-gradient(90deg, rgba(74,144,226,.85), rgba(74,144,226,1));
+               box-shadow:0 0 12px rgba(74,144,226,.35) inset; transition:width .35s ease; }
     .srt-hit{ position:absolute; top:50%; transform:translate(-50%,-50%); width: 10px; height: 10px; border-radius:50%;
               background:#222; border:2px solid rgba(255,255,255,.25); }
     .srt-hit.on{ background:var(--primary); border-color:var(--primary); }
@@ -153,7 +154,7 @@
 
     /* Tabla */
     #sorteos-table th{ background:var(--dark-lighter); color:var(--primary); font-weight:600; text-transform:uppercase; font-size:.8rem; }
-    #sorteos-table td{ color:var(--text-light); border-bottom:1px solid rgba(255,255,255,.05); }
+    #sorteos-table td{ color:var(--text-light); border-bottom:1px solid rgba(0,0,0,.05); }
   
 
   /* === NUMINA: Modal de producto pantalla completa === */
@@ -161,22 +162,22 @@
   .nm-overlay.show{display:block;}
   .nm-modal{position:relative;min-height:100vh;background:#111214;color:#fff;display:flex;flex-direction:column;}
   .nm-modal header{display:flex;justify-content:space-between;align-items:center;padding:16px 18px;background:#1a1b1f;border-bottom:1px solid #24262b}
-  .nm-modal header h3{margin:0;font-size:18px;color:#ffd700;letter-spacing:.3px}
+  .nm-modal header h3{margin:0;font-size:18px;color:var(--primary);letter-spacing:.3px}
   .nm-close{background:transparent;border:0;color:#b7b7b7;font-size:22px;cursor:pointer}
   .nm-body{flex:1;display:grid;grid-template-columns:0.85fr 1.15fr;gap:22px;padding:22px;max-width:1200px;margin:0 auto}
   .nm-imgbox{background:#222;border-radius:16px;display:flex;align-items:center;justify-content:center;overflow:hidden;aspect-ratio:1/1;max-width:520px;width:100%;margin:0 auto}
   .nm-imgbox img{width:100%;height:100%;display:block;object-fit:contain}
   .nm-info h4{margin:.2rem 0 .6rem;font-size:22px}
   .nm-desc{color:#d0d0d0;line-height:1.55;margin:0 0 14px}
-  .nm-price{font-size:24px;font-weight:900;margin:10px 0 18px;color:#ffd700}
+  .nm-price{font-size:24px;font-weight:900;margin:10px 0 18px;color:var(--primary)}
   .nm-actions{display:flex;gap:10px;align-items:center;margin-top:6px}
   .nm-btn{background:transparent;border:1px solid #3a3a3a;color:#fafafa;padding:11px 14px;border-radius:12px;cursor:pointer}
-  .nm-buy{background:#ffd700;color:#111;border:0;padding:12px 18px;border-radius:12px;font-weight:900;cursor:pointer}
+  .nm-buy{background:var(--primary);color:#fff;border:0;padding:12px 18px;border-radius:12px;font-weight:900;cursor:pointer}
   .nm-note{font-size:12px;color:#9aa0a6;margin-top:8px}
   @media(max-width:900px){.nm-body{flex:1;display:grid;grid-template-columns:0.85fr 1.15fr;gap:22px;padding:22px;max-width:1200px;margin:0 auto}
 
   .nm-pitch{margin:10px 0 14px;padding:12px 14px;border:1px solid #2b2e34;background:#16181d;border-radius:12px;line-height:1.55;color:#e7e7e7}
-  .nm-pitch strong{color:#ffd700}
+  .nm-pitch strong{color:var(--primary)}
 }
 
 
@@ -191,7 +192,7 @@
 
 
 /* inline filter bar for purchases */
-.table-filter-inline{display:flex;gap:.6rem;align-items:center;justify-content:flex-end;background:var(--dark-light);padding:.6rem .8rem;border-bottom:1px solid rgba(255,255,255,.05)}
+.table-filter-inline{display:flex;gap:.6rem;align-items:center;justify-content:flex-end;background:var(--dark-light);padding:.6rem .8rem;border-bottom:1px solid rgba(0,0,0,.05)}
 .table-filter-inline input{background:#0f0f0f;border:1px solid rgba(255,255,255,.08);border-radius:10px;padding:.45rem .7rem;color:#f0f0f0;outline:none;min-width:260px}
 .table-filter-inline input::placeholder{color:#8a8a8a}
 
@@ -2107,10 +2108,10 @@ if (!link) {
   .pd-overlay{position:fixed;inset:0;background:rgba(0,0,0,.82);display:none;z-index:1100;padding:24px}
   .pd-overlay.show{display:block}
   .pd-modal{width:min(920px,95vw);margin:auto;border-radius:16px;
-    background:linear-gradient(135deg,rgba(255,215,0,.06),rgba(255,215,0,.02) 24%,#111 60%);
-    border:1px solid rgba(255,215,0,.14);box-shadow:0 18px 50px rgba(0,0,0,.55);color:#fff;font-family:Montserrat,system-ui,sans-serif}
-  .pd-modal header{display:flex;align-items:center;justify-content:space-between;padding:18px 22px;border-bottom:1px solid rgba(255,215,0,.14)}
-  .pd-modal header h3{margin:0;color:var(--primary, #ffd700);font-size:1.35rem;letter-spacing:.3px}
+    background:linear-gradient(135deg,rgba(74,144,226,.06),rgba(74,144,226,.02) 24%,#111 60%);
+    border:1px solid rgba(74,144,226,.14);box-shadow:0 18px 50px rgba(0,0,0,.55);color:#fff;font-family:Montserrat,system-ui,sans-serif}
+  .pd-modal header{display:flex;align-items:center;justify-content:space-between;padding:18px 22px;border-bottom:1px solid rgba(74,144,226,.14)}
+  .pd-modal header h3{margin:0;color:var(--primary);font-size:1.35rem;letter-spacing:.3px}
   .pd-x{background:transparent;border:0;color:#cfcfcf;font-size:22px;font-weight:700;cursor:pointer}
   .pd-content{display:grid;grid-template-columns:260px 1fr;gap:18px;padding:20px 22px 8px}
   .pd-media{background:#1f1f1f;border:1px solid rgba(255,255,255,.08);border-radius:12px;aspect-ratio:5/6;display:flex;align-items:center;justify-content:center;overflow:hidden}
@@ -2123,20 +2124,20 @@ if (!link) {
   .pd-status.active{background:rgba(40,167,69,.18);color:var(--ok,#28a745);}
   .pd-status.cancelled{background:rgba(220,53,69,.18);color:var(--danger,#dc3545);}
   .pd-status.completed{background:rgba(13,110,253,.20);color:#0d6efd;}
-  .pd-hr{height:1px;background:linear-gradient(90deg,transparent,rgba(255,215,0,.25),transparent);margin:12px 0}
+  .pd-hr{height:1px;background:linear-gradient(90deg,transparent,rgba(74,144,226,.25),transparent);margin:12px 0}
   .pd-actions{display:flex;flex-wrap:wrap;gap:.7rem;padding:0 22px 18px}
   .pd-btn{border-radius:12px;padding:.6rem 1rem;font-weight:800;letter-spacing:.2px;border:1px solid transparent;cursor:pointer}
-  .pd-btn.gold{background:var(--primary, #ffd700);color:#111;border-color:var(--primary, #ffd700)}
+  .pd-btn.gold{background:var(--primary);color:#fff;border-color:var(--primary)}
   .pd-btn.warn{background:#ffc107;color:#111;border-color:#ffc107}
-  .pd-btn.outline{background:transparent;color:var(--primary, #ffd700);border-color:rgba(255,215,0,.7)}
+  .pd-btn.outline{background:transparent;color:var(--primary);border-color:rgba(74,144,226,.7)}
   .pd-grid{display:grid;grid-template-columns:1fr 1fr;gap:14px;padding:0 22px 22px}
   .pd-card{background:linear-gradient(180deg,#141414,#101010);border:1px solid rgba(255,255,255,.06);border-radius:12px;padding:12px 14px}
-  .pd-card h5{margin:0 0 .4rem;color:var(--primary, #ffd700);font-size:.95rem}
+  .pd-card h5{margin:0 0 .4rem;color:var(--primary);font-size:.95rem}
   .pd-kv{display:grid;grid-template-columns:150px 1fr;gap:.4rem .8rem;color:#eaeaea;font-size:.92rem}
   .pd-kv .k{color:#a7a7a7}
   .pd-timeline{display:grid;gap:.6rem}
   .pd-tl{display:grid;grid-template-columns:18px 1fr;gap:.6rem;align-items:start}
-  .pd-dot{width:10px;height:10px;border-radius:50%;background:var(--primary, #ffd700);box-shadow:0 0 0 3px rgba(255,215,0,.15)}
+  .pd-dot{width:10px;height:10px;border-radius:50%;background:var(--primary);box-shadow:0 0 0 3px rgba(74,144,226,.15)}
   @media(max-width:860px){.pd-content{grid-template-columns:1fr}}
 
 .btn-delete-row{border:1px solid #f5c400;color:#f5c400;background:transparent;
@@ -2648,10 +2649,10 @@ if (!link) {
 .sc-overlay{position:fixed;inset:0;background:rgba(0,0,0,.75);display:none;z-index:2000;}
 .sc-overlay.show{display:block;}
 .sc-modal{position:relative;width:min(1100px,92vw);margin:6vh auto;background:#161616;color:#fff;
-  border:1px solid rgba(255,215,0,.25); border-radius:18px; box-shadow:0 18px 60px rgba(0,0,0,.5);}
+  border:1px solid rgba(74,144,226,.25); border-radius:18px; box-shadow:0 18px 60px rgba(0,0,0,.5);}
 .sc-close{position:absolute;right:16px;top:16px;width:40px;height:40px;border-radius:999px;border:1px solid #333;
   background:transparent;color:#cfcfcf;font-size:20px;cursor:pointer}
-.sc-modal h3{font-size:28px; font-weight:900; color:var(--primary,#ffd700); margin:24px 24px 10px}
+.sc-modal h3{font-size:28px; font-weight:900; color:var(--primary); margin:24px 24px 10px}
 .sc-body{padding:0 24px 24px}
 .sc-grid{display:grid;grid-template-columns: 1fr 1fr; gap:20px; margin-top:8px}
 @media(max-width:900px){.sc-grid{grid-template-columns:1fr}}
@@ -2669,8 +2670,8 @@ if (!link) {
 .sc-textarea{min-height:140px;resize:vertical}
 .sc-actions{display:flex;gap:12px; align-items:center; padding:0 24px 24px}
 .sc-btn{border-radius:12px;padding:12px 18px;font-weight:900;cursor:pointer;border:1px solid transparent}
-.sc-btn-gold{background:var(--primary,#ffd700); color:#111}
-.sc-btn-ghost{background:transparent; color:#ffd700; border-color:rgba(255,215,0,.45)}
+.sc-btn-gold{background:var(--primary); color:#fff}
+.sc-btn-ghost{background:transparent; color:var(--primary); border-color:rgba(74,144,226,.45)}
 .sc-err{color:#f87171; font-size:13px; margin-top:6px; display:none}
 
 .btn-delete-row{border:1px solid #f5c400;color:#f5c400;background:transparent;

--- a/login.html
+++ b/login.html
@@ -8,27 +8,25 @@
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <style>
     :root{
-      --bg:#0f1113; --panel:#16181c; --panel-2:#1d2025; --text:#fff; --muted:#a7aeb8;
-      --brand:#ffd700; --brand-2:#e6c200; --danger:#ff6b6b; --ok:#44d07b;
+      --primary:#4a90e2; --secondary:#50e3c2;
+      --bg:#f4f4f4; --panel:#ffffff; --panel-2:#f9f9f9; --text:#333; --muted:#555;
+      --danger:#ff6b6b; --ok:#44d07b;
     }
     *{box-sizing:border-box}
     html,body{height:100%;margin:0}
     body{
       font-family:'Montserrat',system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
-      background:
-        radial-gradient(1200px 800px at 20% -10%, #15181d 0%, transparent 60%),
-        radial-gradient(1200px 800px at 120% 110%, #15181d 0%, transparent 60%),
-        var(--bg);
+      background: var(--bg);
       color:var(--text);
       display:flex;align-items:center;justify-content:center;padding:24px;
     }
     .login-container{
       width:min(480px,100%);
       background:linear-gradient(180deg,var(--panel) 0%, var(--panel-2) 100%);
-      border:1px solid rgba(255,255,255,.08);
+      border:1px solid rgba(0,0,0,.1);
       border-radius:16px;
       padding:24px;
-      box-shadow:0 20px 45px rgba(0,0,0,.45);
+      box-shadow:0 20px 45px rgba(0,0,0,.1);
       position:relative;
     }
     .topbar{ display:flex;align-items:center;justify-content:flex-end;margin-bottom:6px; }
@@ -36,13 +34,13 @@
     /* Dropdown idioma (pill amarilla) */
     .lang-dropdown{ position:relative; display:inline-block; }
     .lang-btn{
-      background:var(--brand);
+      background:var(--secondary);
       border:0; border-radius:999px; padding:6px 14px; cursor:pointer;
-      color:#111; font-weight:900; display:inline-flex; align-items:center; gap:8px;
+      color:#fff; font-weight:900; display:inline-flex; align-items:center; gap:8px;
       box-shadow:inset 0 -2px 0 rgba(0,0,0,.15), 0 2px 8px rgba(0,0,0,.25);
     }
-    .lang-btn:focus{ outline:none; box-shadow:0 0 0 3px rgba(255,215,0,.3); }
-    .lang-btn .chevron{ width:12px; height:12px; fill:none; stroke:#111; stroke-width:2px; transition:transform .18s ease; }
+    .lang-btn:focus{ outline:none; box-shadow:0 0 0 3px rgba(80,227,194,.3); }
+    .lang-btn .chevron{ width:12px; height:12px; fill:none; stroke:#fff; stroke-width:2px; transition:transform .18s ease; }
     .lang-dropdown.open .lang-btn .chevron{ transform:rotate(180deg); }
     .lang-menu{
       position:absolute; top:110%; right:0; z-index:20;
@@ -55,31 +53,31 @@
       display:flex; align-items:center; gap:10px; padding:10px 14px; cursor:pointer;
       font-weight:700; user-select:none; white-space:nowrap;
     }
-    .lang-item:hover, .lang-item[aria-selected="true"]{ background:var(--brand); color:#111; }
+    .lang-item:hover, .lang-item[aria-selected="true"]{ background:var(--secondary); color:#fff; }
     .lang-flag{ width:18px; height:18px; display:inline-flex; align-items:center; justify-content:center; }
 
     .brand{ display:flex;gap:10px;align-items:center;justify-content:center;margin:8px 0 16px; }
     .brand .logo{
       width:38px;height:38px;border-radius:10px;
-      background:linear-gradient(135deg,#4b4300,#8a7a00);
-      display:grid;place-items:center;font-weight:900;color:#111;
+      background:linear-gradient(135deg,var(--primary),var(--secondary));
+      display:grid;place-items:center;font-weight:900;color:#fff;
     }
-    .brand h2{ margin:0; font-size:1.9rem; letter-spacing:1.4px; color:var(--brand); }
+    .brand h2{ margin:0; font-size:1.9rem; letter-spacing:1.4px; color:var(--primary); }
 
-    .tabs{ display:flex;background:#11151a;border:1px solid rgba(255,255,255,.06); border-radius:12px;padding:4px;margin-bottom:16px; }
+    .tabs{ display:flex;background:#fff;border:1px solid rgba(0,0,0,.06); border-radius:12px;padding:4px;margin-bottom:16px; }
     .tab{ flex:1;text-align:center;padding:10px 12px;border-radius:8px; font-weight:700;color:var(--muted);cursor:pointer;user-select:none; }
     .tab.active{ background:var(--panel); color:var(--text); }
 
     h1{display:none}
     label{ display:block; font-size:.88rem; color:var(--muted); margin:4px 0 6px; }
     input{
-      width:100%; background:#0f1318; border:1px solid #232832; border-radius:10px;
+      width:100%; background:#fff; border:1px solid #ced4da; border-radius:10px;
       color:var(--text); padding:12px 14px; margin-bottom:14px; font-size:1rem;
       outline:none; transition:.18s box-shadow,.18s border-color;
     }
-    input:focus{ border-color:#2e3746; box-shadow:0 0 0 3px rgba(255,215,0,.15); }
+    input:focus{ border-color:var(--primary); box-shadow:0 0 0 3px rgba(74,144,226,.15); }
     .login-button{
-      width:100%; background:var(--brand); color:#111; border:0; border-radius:999px;
+      width:100%; background:var(--primary); color:#fff; border:0; border-radius:999px;
       padding:12px 14px; font-weight:900; cursor:pointer; transition:.18s transform, .18s box-shadow;
     }
     .login-button:hover{ transform:translateY(-1px); box-shadow:0 6px 18px rgba(0,0,0,.3); }
@@ -87,8 +85,8 @@
     button{ transition:transform .2s ease, box-shadow .2s ease; }
     button:hover{ transform:translateY(-2px); box-shadow:0 8px 24px rgba(0,0,0,.35); }
     .login-container{ transition:transform .2s ease, box-shadow .2s ease; }
-    .login-container:hover{ transform:translateY(-2px); box-shadow:0 24px 48px rgba(0,0,0,.5); }
-    .toggle-form{ display:block; margin-top:10px; color:var(--brand); cursor:pointer; text-align:center; }
+    .login-container:hover{ transform:translateY(-2px); box-shadow:0 24px 48px rgba(0,0,0,.2); }
+    .toggle-form{ display:block; margin-top:10px; color:var(--secondary); cursor:pointer; text-align:center; }
     .toggle-form:hover{ text-decoration:underline; }
     #error-message, #register-error-message, #reset-error, #reset-success, #newpass-error, #newpass-success{
       min-height:20px; margin-top:10px; text-align:center;
@@ -98,15 +96,15 @@
     .row-2{ display:grid; grid-template-columns:1fr 1fr; gap:12px; }
     @media (max-width: 520px){ .row-2{ grid-template-columns:1fr; } }
     .muted { color: var(--muted); font-size:.88rem; text-align:center; margin-top:8px; }
-    .link { color: var(--brand); cursor:pointer; }
+    .link { color: var(--secondary); cursor:pointer; }
     .link:hover{ text-decoration: underline; }
     .help { font-size:.8rem; color:var(--muted); margin-top:-8px; margin-bottom:12px; }
     /* --- Highlight de referido --- */
-  label[for="register-refcode"]{ color: var(--brand); font-weight: 800; }
-  #register-refcode{ border-color: rgba(255,215,0,.35); }
-  #register-refcode:focus{ border-color: var(--brand); box-shadow:0 0 0 3px rgba(255,215,0,.2); }
-  #register-refcode::placeholder{ color: rgba(255,215,0,.75); }
-  #ref-hint{ color: var(--brand); }
+  label[for="register-refcode"]{ color: var(--primary); font-weight: 800; }
+  #register-refcode{ border-color: rgba(74,144,226,.35); }
+  #register-refcode:focus{ border-color: var(--primary); box-shadow:0 0 0 3px rgba(74,144,226,.2); }
+  #register-refcode::placeholder{ color: rgba(74,144,226,.75); }
+  #ref-hint{ color: var(--secondary); }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- introduce new --primary and --secondary palette with light backgrounds
- apply refreshed colors to headers, buttons and cards across dashboard and login

## Testing
- `npx -y htmlhint index.html login.html` *(fails: Tag name lowercase, tag pairing and character escape errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d43721108330a7600bf12871dca1